### PR TITLE
build: :arrow_up: update Kotlin version to `2.1.0` (latest)

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.7.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary

This pull request updates the Kotlin version used in the Android build configuration to **2.1.0** to address Flutter's upcoming deprecation of older Kotlin versions.

## Reason for Change

Flutter now displays a deprecation warning for projects using Kotlin versions below 2.1.0:

> ⚠️ **Warning:** Flutter support for your project's Kotlin version (1.8.10) will soon be dropped. Please upgrade your Kotlin version to a version of at least 2.1.0 soon.

To maintain compatibility with future Flutter releases and avoid build issues, upgrading to Kotlin 2.1.0 is required.

## Changes

| File | Property | Previous Version | New Version |
|------|----------|------------------|-------------|
| `example/android/build.gradle` | `ext.kotlin_version` | `1.8.10` | `2.1.0` |
| `example/android/settings.gradle` | `org.jetbrains.kotlin.android` plugin | `1.8.22` | `2.1.0` |

## Benefits

- ✅ Resolves Flutter deprecation warning
- ✅ Ensures compatibility with future Flutter versions
- ✅ Enables access to latest Kotlin features and improvements
- ✅ Maintains consistency between build script and plugin management