### PR TITLE
build: :arrow_up: bump NDK version to the latest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ android {
             }
         }
     }
-    ndkVersion '29.0.14033849'
+    ndkVersion '29.0.14206865'
 
 
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -10,7 +10,7 @@ android {
         namespace "com.emrys.rjsniffer.rjsniffer_example"
     }
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "29.0.14033849"
+    ndkVersion = "29.0.14206865"
 
 
     compileOptions {


### PR DESCRIPTION
This pull request updates the NDK version used in the Android build configuration files to a newer version. This ensures consistency across the project and may include important bug fixes or improvements from the updated NDK.

Android build configuration updates:

* Updated the `ndkVersion` from `29.0.14033849` to `29.0.14206865` in `android/build.gradle` to use a newer NDK version.
* Updated the `ndkVersion` from `29.0.14033849` to `29.0.14206865` in `example/android/app/build.gradle` for the example app.